### PR TITLE
Fix JSON output

### DIFF
--- a/smalisca/core/smalisca_app.py
+++ b/smalisca/core/smalisca_app.py
@@ -280,7 +280,7 @@ class App:
         """Write app object as JSON to file"""
         try:
             with open(filename, 'w+') as f:
-                json.dump(self.to_json(), f, indent=JSON_SETTINGS['indent'])
+                f.write(self.to_json())
 
         except IOError:
             log.error("Couldn't save data to %s" % filename)


### PR DESCRIPTION
JSON output was being encoded twice (meaning the output would be a JSON-encoded string containing a JSON-encoded document).

This change removes the second JSON dump so that the output is a valid JSON document.
