### PR TITLE
remove regex semicolon to allow arrays in call dst_class

### DIFF
--- a/smalisca/modules/module_smali_parser.py
+++ b/smalisca/modules/module_smali_parser.py
@@ -410,7 +410,7 @@ class SmaliParser(ModuleBase):
         # The call looks like this
         #  <destination class>) -> <method>(args)<return value>
         match = re.search(
-            '(?P<local_args>\{.*\}),\s+(?P<dst_class>.*);->' +
+            '(?P<local_args>\{.*\}),\s+(?P<dst_class>.*)->' +
             '(?P<dst_method>.*)\((?P<dst_args>.*)\)(?P<return>.*)', data)
 
         if match:


### PR DESCRIPTION
Previously the semicolon before the arrow dictated that the dst_class had to be something that ended with a semicolon, however this is not always the case. You could have a case where an array is used with a primitive type, such as 

invoke-virtual {v2}, [J->clone()Ljava/lang/Object;

To account for this, we can just remove the semicolon from the regex so that any dst_class before the -> can be parsed
