### PR TITLE
Parse annotations out of smali

### DIFF
--- a/smalisca/core/smalisca_analysis.py
+++ b/smalisca/core/smalisca_analysis.py
@@ -35,7 +35,7 @@
 import abc
 
 
-class AnalysisBase(metaclass=abc.ABCMeta):
+class AnalysisBase(abc.ABCMeta):
     """Basic analysis class
 
     Provides abstract methods how to interact with the results.


### PR DESCRIPTION
There is probably some more work to be done here, but this will extract the class and value out of annotations. 

I also added a small change here since having `metaclass=` was causing problems and I didn't see why this needed to be a metaclass? If there was a reason for this being a metaclass I can change it back and debug my crash further.